### PR TITLE
棋譜の保存の実装

### DIFF
--- a/data/ex/2024-01-01.csv
+++ b/data/ex/2024-01-01.csv
@@ -1,3 +1,3 @@
-White Point,White ID,White Name,White Kanji,White K,White Rating,Black ID,Black Name,Black Kanji,Black K,Black Rating,Date,Time,Source
-1,N01234567,Tanaka Satoshi,田中 智,20,1600,N01234568,Yamada Taro,山田 太郎,20,1300,2023-12-01,ST,チェスクラブ
-0.5,N01234567,Tanaka Satoshi,田中 智,20,1600,N01234569,Sato Ken,佐藤 健,20,1900,2023-12-01,ST,チェスクラブ
+White Point,White ID,White Name,White Kanji,White K,White Rating,Black ID,Black Name,Black Kanji,Black K,Black Rating,Date,Time,Source,PGN Moves
+1,N01234567,Tanaka Satoshi,田中 智,20,1600,N01234568,Yamada Taro,山田 太郎,20,1300,2023-12-01,ST,チェスクラブ,1. e4 c6 2. Nf3 d5
+0.5,N01234567,Tanaka Satoshi,田中 智,20,1600,N01234569,Sato Ken,佐藤 健,20,1900,2023-12-01,ST,チェスクラブ,

--- a/db/migrate/20240530035237_add_pgn_moves_to_games.rb
+++ b/db/migrate/20240530035237_add_pgn_moves_to_games.rb
@@ -1,0 +1,5 @@
+class AddPgnMovesToGames < ActiveRecord::Migration[7.1]
+  def change
+    add_column :games, :pgn_moves, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,77 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_12_125119) do
-  create_table "2019_players", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "ncs_id", null: false
-    t.string "name_en"
-    t.string "name_jp"
-    t.integer "total_game_count"
-    t.integer "total_win_count"
-    t.integer "total_loss_count"
-    t.integer "total_draw_count"
-    t.float "total_opponent_rating_average"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["ncs_id"], name: "index_2019_players_on_ncs_id", unique: true
-  end
-
-  create_table "2020_players", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "ncs_id", null: false
-    t.string "name_en"
-    t.string "name_jp"
-    t.integer "total_game_count"
-    t.integer "total_win_count"
-    t.integer "total_loss_count"
-    t.integer "total_draw_count"
-    t.float "total_opponent_rating_average"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["ncs_id"], name: "index_2020_players_on_ncs_id", unique: true
-  end
-
-  create_table "2021_players", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "ncs_id", null: false
-    t.string "name_en"
-    t.string "name_jp"
-    t.integer "total_game_count"
-    t.integer "total_win_count"
-    t.integer "total_loss_count"
-    t.integer "total_draw_count"
-    t.float "total_opponent_rating_average"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["ncs_id"], name: "index_2021_players_on_ncs_id", unique: true
-  end
-
-  create_table "2022_players", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "ncs_id", null: false
-    t.string "name_en"
-    t.string "name_jp"
-    t.integer "total_game_count"
-    t.integer "total_win_count"
-    t.integer "total_loss_count"
-    t.integer "total_draw_count"
-    t.float "total_opponent_rating_average"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["ncs_id"], name: "index_2022_players_on_ncs_id", unique: true
-  end
-
-  create_table "2023_players", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "ncs_id", null: false
-    t.string "name_en"
-    t.string "name_jp"
-    t.integer "total_game_count"
-    t.integer "total_win_count"
-    t.integer "total_loss_count"
-    t.integer "total_draw_count"
-    t.float "total_opponent_rating_average"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["ncs_id"], name: "index_2023_players_on_ncs_id", unique: true
-  end
-
+ActiveRecord::Schema[7.1].define(version: 2024_05_30_035237) do
   create_table "games", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "white_id"
     t.integer "white_rating", null: false
@@ -94,6 +24,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_125119) do
     t.string "time_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "pgn_moves"
     t.index ["start_at"], name: "index_games_on_start_at"
     t.index ["tournament_id"], name: "index_games_on_tournament_id"
   end


### PR DESCRIPTION
#1 の実装
`docker-compose exec web rake database:add_pgn_moves`
csv_directories 内の全ての csv ファイルにあるリザルトで、**すでにGames テーブルにレコードが存在するゲームの棋譜のみ**保存します。
Games テーブルに保存されていない場合、新しいレコードを追加した方が良いならば、修正します。

また、 `rails  db:migrate` により schema.rb が大きく変更されてしまいましたが、こちらについてもお教えいただけるとありがたいです。